### PR TITLE
Fix inlcude casing to make on-disc casing

### DIFF
--- a/lib/cml/time.hpp
+++ b/lib/cml/time.hpp
@@ -9,7 +9,7 @@
 
 //cml
 #include <cml/integer.hpp>
-#include <cml/Numeric_traits.hpp>
+#include <cml/numeric_traits.hpp>
 
 namespace cml {
 


### PR DESCRIPTION
The examples fail to compile on case-sensitive filesystems currently.

Closes #29 
