### PR TITLE
[PoC] Add critical section guard type

### DIFF
--- a/lib/soc/interrupt_guard.cpp
+++ b/lib/soc/interrupt_guard.cpp
@@ -1,0 +1,33 @@
+/*
+    Name: interrupt_guard.cpp
+
+    Copyright(c) 2020 Jay Kickliter
+    This code is licensed under MIT license (see LICENSE file for details)
+*/
+
+//this
+#include <soc/interrupt_guard.hpp>
+
+//externals
+#ifdef STM32L452xx
+#include <stm32l4xx.h>
+#endif
+
+#ifdef STM32L011xx
+#include <stm32l0xx.h>
+#endif
+
+namespace soc {
+
+Interrupt_guard::Interrupt_guard()
+    : primask(__get_PRIMASK())
+{
+    __disable_irq();
+}
+
+Interrupt_guard::~Interrupt_guard()
+{
+    __set_PRIMASK(this->primask);
+}
+
+} // namespace soc

--- a/lib/soc/interrupt_guard.hpp
+++ b/lib/soc/interrupt_guard.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+/*
+    Name: interrupt_guard.hpp
+
+    Copyright(c) 2020 Jay Kickliter
+    This code is licensed under MIT license (see LICENSE file for details)
+*/
+
+//std
+#include <cstdint>
+
+namespace soc {
+
+/**
+ * Provides an RAII style uninterruptible section.
+ *
+ * `Interrupt_guard` disables interrupts for its entire lifetime
+ * so care must be taken to limit it's scope when constructed.
+ *
+ * # Example
+ *
+ *     // Interrupts are enabled, but we need to update a
+ *     // non-atomic global variable.
+ *
+ *     {
+ *         Interrupt_guard guard;
+ *         // interrupts now disabled until next closing brace.
+ *         some_large_global = SomeLargeStruct();
+ *     }   // guard's destructor called here
+ *     // Interrupts are enabled.
+ */
+class Interrupt_guard {
+  public:
+    Interrupt_guard();
+    ~Interrupt_guard();
+
+    Interrupt_guard(Interrupt_guard&&)      = delete;
+    Interrupt_guard(const Interrupt_guard&) = delete;
+    Interrupt_guard& operator=(Interrupt_guard&&) = delete;
+    Interrupt_guard& operator=(const Interrupt_guard&) = delete;
+
+  private:
+    uint32_t primask;
+};
+
+} // namespace soc

--- a/lib/soc/systick.cpp
+++ b/lib/soc/systick.cpp
@@ -21,6 +21,9 @@
 //cml
 #include <cml/bit.hpp>
 
+//soc
+#include <soc/interrupt_guard.hpp>
+
 namespace
 {
 
@@ -66,11 +69,13 @@ void systick::disable()
 
 void systick::register_tick_callback(const Tick_callback& a_callback)
 {
+    Interrupt_guard guard;
     callback = a_callback;
 }
 
 void systick::unregister_tick_callback()
 {
+    Interrupt_guard guard;
     callback.function    = nullptr;
     callback.p_user_data = nullptr;
 }


### PR DESCRIPTION
I'm marking this PR proof-of-concept because I haven't run it on any hardware. But I have implemented and used a similar guard type in the past though with success. Feel free to close outright or pick or modify as you wish.

## Motivation

Although it isn't limited to this use-case, I noticed that callback setters/getters in CML are not interrupt-safe. Not being so exposes interrupt handlers to the not-unlikely possibility of torn-reads.

In the following example both the callback function and callback data are already set, and the application is updating them.

```c++
void component::register_callback(const component_callback & cb)
{
    // callback = a_callback;
    // Let's break down the above struct assignment
    // to its individual operations:
    callback.funciton  = cb.function;
    ---------------------------------- Interrupt here ------------------------------------
                                      void Component_Handler()
                                      {
                                          if (nullptr != callback.function)
                                          {
                                              // callback.function is the new
                                              // function pointer, but callback.user_data
                                              // is the old value since it hasn't yet been
                                              // set in the main thread
                                              callback.function(callback.user_data);
                                          }
                                      }
    ----------------------------------- Interrupt done ------------------------------------
    callback.user_data = cb.user_data;
}
```

## Usage

See the modified `systick.cpp` for an example how to use this type.

## Alternatives

An alternative could be to have a higher-order function executes a user provided lambda with interrupts disabled:

```c++
#include <functional>

struct component_callback
{
    using Function = void(*)(void* a_p_user_data);
    Function function = nullptr;
    void* p_user_data = nullptr;
};

// Executes critical_fn with interrupts disabled.
template<class F>
void critical_do(F critical_fn)
{
    // Backup PRIMASK
    // Disable interrupts
    critical_fn();
    // Restore PRIMASK
}

component_callback callback;

void register_callback(const component_callback & cb)
{
    critical_do([&]() { callback = cb; });
}
```
